### PR TITLE
[feature] handling facebook optins

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,7 +7,7 @@ const defaults = {
   access_token: '',
   provider: 'generic',
   fb: {
-    apiVersion: 'v2.7',
+    version: 'v2.7',
   },
 }
 
@@ -26,10 +26,11 @@ exports.register = (server, options, next) => {
       // Apply defaults options to received options
       logger.debug('Getting configuration for hapi-ham')
       const config = _.cloneDeep(_.defaults(options, defaults))
-
       // Get proxy from url query param
       config.proxy = request.query.proxy || config.proxy
-      config.extraParams = request.query['callback-url'] ? `&callback-url=${request.query['callback-url']}` : ''
+      config.extraParams = request.query['callback-url']
+        ? `&callback-url=${request.query['callback-url']}`
+        : ''
 
       // We are defining a fbUrl if there isn't a config for a proxy
       const fbUrl = `https://graph.facebook.com/${

--- a/lib/index.js
+++ b/lib/index.js
@@ -24,8 +24,9 @@ exports.register = (server, options, next) => {
   server.ext('onPreHandler', (request, reply) => {
     if (request.method === 'post') {
       // Apply defaults options to received options
-      logger.debug('Getting configuration for hapi-ham')
       const config = _.cloneDeep(_.defaults(options, defaults))
+      logger.debug('Getting configuration for hapi-ham: %j', config)
+
       // Get proxy from url query param
       config.proxy = request.query.proxy || config.proxy
       config.extraParams = request.query['callback-url']

--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -4,8 +4,13 @@ const Helpers = require('../helpers')
 
 const getSend = (data, config, logger, event) => (message, _options) => {
   let tokenParam = ''
+  const recipientKey = event.optin ? 'user_ref' : 'id'
+  const recipientId = event.optin
+    ? event.optin.user_ref
+    : _options.userId || event.sender.id
+
   const payload = {
-    recipient: { id: _options.userId || event.sender.id },
+    recipient: { [recipientKey]: recipientId },
   }
 
   if (_options.botToken) {
@@ -87,7 +92,10 @@ const process = (request, config, logger) => {
     }
 
     // If event has a sender id then get funciont 'send' used to send message to provider
-    if (event.sender && event.sender.id) {
+    if (
+      (event.sender && event.sender.id) ||
+      (event.optin && event.optin.user_ref)
+    ) {
       logger.debug('Getting send function for Facebook provider')
       send = getSend({}, config, logger, event)
     }


### PR DESCRIPTION
Allow to `hapi-ham` support `optins` messages from Facebook. It's necessary when we use checkbox plugin feature. Was added  the capability to answer with `user_ref` instead of the usual `PSID` 
