### PR TITLE
Convert optin.ref to ref param

### DIFF
--- a/lib/providers/facebook.js
+++ b/lib/providers/facebook.js
@@ -90,6 +90,8 @@ const process = (request, config, logger) => {
       request.refParams = Helpers.strParamToParamList(event.postback.referral.ref)
     } else if (event.referral && event.referral.ref) {
       request.refParams = Helpers.strParamToParamList(event.referral.ref)
+    } else if (event.optin && event.optin.ref) {
+      request.refParams = Helpers.strParamToParamList(event.optin.ref)
     }
 
     config.source = _.get(event, 'message.tags.source', 'messenger')


### PR DESCRIPTION
Convert optin.ref value sent by Messenger Checkbox plugin to ref param structure.